### PR TITLE
Recursion for non-unix path, and no actual path-change

### DIFF
--- a/src/jadelint.coffee
+++ b/src/jadelint.coffee
@@ -31,7 +31,7 @@ jadelint = (conf, reporter = new Reporter, callback = ->) ->
 
             lastDir = dir
             dir = path.join dir, '..'
-        return def
+        def
 
     conf ?= getDefaultConf()
 

--- a/src/jadelint.coffee
+++ b/src/jadelint.coffee
@@ -23,14 +23,15 @@ jadelint = (conf, reporter = new Reporter, callback = ->) ->
     getDefaultConf = () ->
         def = {}
         dir = process.cwd()
-        while '/' isnt fs.realpathSync dir
+        lastDir = ''
+        while dir isnt lastDir
             try
                 for prop, val of JSON.parse fs.readFileSync "#{dir}/.jadelintrc"
                     def[prop] ?= val
 
-            dir += '/..'
-
-        def
+            lastDir = dir
+            dir = path.join dir, '..'
+        return def
 
     conf ?= getDefaultConf()
 


### PR DESCRIPTION
In Windows you'll never reach '/'

It should be faster to just change the path string and not sync-step down the path path.
